### PR TITLE
Update DotStarBridgedLED.java

### DIFF
--- a/LEDs/DotStarBridgedLED.java
+++ b/LEDs/DotStarBridgedLED.java
@@ -159,7 +159,12 @@ public class DotStarBridgedLED extends I2cDeviceSynchDeviceWithParameters<I2cDev
             this.pixels = Arrays.copyOf(this.pixels, length);
 
             for (int i = oldLength; i < length; i++) {
-                this.pixels[i].reset();
+                // This should allow handling multiple calls to setLength.
+                if(this.pixels[i] == null) {
+                    this.pixels[i] = new DotStarBridgedLED.Pixel(0, 0, 0);
+                } else {
+                    this.pixels[i].reset();
+                }
             }
         }
     }


### PR DESCRIPTION
Fix bug the prevented calling setLength with anything greater than the default length.